### PR TITLE
docs(zonal): complete user and API documentation for zonal model

### DIFF
--- a/docs/source/api/io_manager.md
+++ b/docs/source/api/io_manager.md
@@ -13,6 +13,8 @@ Functions for loading input data and exporting results.
 ```{eval-rst}
 .. autofunction:: sdom.io_manager.get_formulation
 
+.. autofunction:: sdom.io_manager.get_network_formulation
+
 .. autofunction:: sdom.io_manager.check_formulation
 ```
 
@@ -91,3 +93,18 @@ The `load_data()` function returns a dictionary with these keys:
 - `scalars`: System-level parameters
 - `import_cap`, `export_cap` (optional): Trade capacity limits
 - `import_prices`, `export_prices` (optional): Trade prices
+
+Zonal additions when the input folder uses area-aware encoding:
+
+- `areas`: list of area descriptors
+- `lines`: list of line descriptors (`line_id`, `from_area`, `to_area`)
+- `line_cap_ft`, `line_cap_tf`: directional line-capacity DataFrames
+- `per_area_demand`, `per_area_pv_plants`, `per_area_wind_plants`, `per_area_balancing_units`, `per_area_storage`, `per_area_hydro`
+- `per_area_nuclear`, `per_area_other_renewables`, `per_area_imports`, `per_area_exports`
+- `per_area_capacity_factors_pv`, `per_area_capacity_factors_wind`
+
+`load_data()` behavior by network formulation:
+
+- If `Network` is missing from `formulations.csv`, SDOM defaults to `CopperPlateNetwork`.
+- If `Network=AreaTransportationModelNetwork`, SDOM validates and requires `interconnections.csv`, `LineCap_FT.csv`, and `LineCap_TF.csv`.
+- If zonal data is present but `Network=CopperPlateNetwork`, SDOM aggregates areas into a single synthetic `default` area and drops transmission topology/capacity files.

--- a/docs/source/api/models.md
+++ b/docs/source/api/models.md
@@ -56,6 +56,24 @@ Documentation for model formulation modules.
    :show-inheritance:
 ```
 
+## Network (Zonal) Formulations
+
+```{eval-rst}
+.. automodule:: sdom.models.formulations_network
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+## Host Pattern in Formulation Builders
+
+Most `add_*_*` model-builder functions now use `host` as the first argument.
+
+- In copper-plate mode, `host` is the top-level model.
+- In zonal mode, `host` is `model.area[a]` for each area.
+
+This pattern allows the same formulation builders to populate either top-level blocks or per-area blocks.
+
 ## Model Utilities
 
 Helper functions for building model components.

--- a/docs/source/api/parametric.md
+++ b/docs/source/api/parametric.md
@@ -5,6 +5,15 @@ API reference for the `sdom.parametric` sub-package.
 See the [user guide](../user_guide/parametric_analysis.md) for a full
 usage walkthrough and worked examples.
 
+## Zonal Notes
+
+`ParametricStudy` supports zonal runs and can execute global scalar sweeps on zonal datasets.
+
+Current behavior for zonal mode:
+
+- Global scalar mutations (for example `GenMix_Target`) propagate correctly.
+- Per-area targeted mutations are not yet a first-class API (deferred follow-up).
+
 ---
 
 ## ParametricStudy

--- a/docs/source/api/results.md
+++ b/docs/source/api/results.md
@@ -153,3 +153,25 @@ print(f"Binary Variables: {problem_info['Number of binary variables']}")
 | `storage_df` | pd.DataFrame | Hourly storage operation |
 | `thermal_generation_df` | pd.DataFrame | Disaggregated thermal generation |
 | `summary_df` | pd.DataFrame | Summary metrics |
+
+### Zonal Fields
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `is_zonal` | bool | True when collected from a zonal model (`model.A` and `model.area` present). |
+| `areas` | list | Area IDs in the solved zonal model. |
+| `lines` | list | Line metadata (`line_id`, `from_area`, `to_area`). |
+| `area_capacity` | dict | Per-area installed capacities. |
+| `area_storage_capacity` | dict | Per-area storage capacities (`charge`, `discharge`, `energy`). |
+| `area_generation_totals` | dict | Per-area generation totals. |
+| `area_cost_breakdown` | dict | Per-area cost breakdown. |
+| `area_generation_df` | dict[str, pd.DataFrame] | Hourly generation by area. |
+| `area_storage_df` | dict[str, pd.DataFrame] | Hourly storage operation by area. |
+| `area_thermal_generation_df` | dict[str, pd.DataFrame] | Thermal generation by area. |
+| `area_installed_plants_df` | dict[str, pd.DataFrame] | Installed plants by area. |
+| `area_summary_df` | dict[str, pd.DataFrame] | Per-area summary DataFrames. |
+| `interregional_exchanges_df` | pd.DataFrame | Per-line/per-hour flow, directional capacity, and utilization. |
+
+Collector dispatch behavior:
+
+- `collect_results_from_model(...)` uses the zonal collector when both `model.A` and `model.area` exist.
+- In zonal mode, `summary_df` is intentionally left empty and replaced by `area_summary_df`.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -90,12 +90,15 @@ if results.is_optimal:
 
 user_guide/introduction
 user_guide/inputs
+user_guide/zonal_inputs
 user_guide/running_and_outputs
+user_guide/zonal_model
 user_guide/parametric_analysis
 user_guide/resiliency
 user_guide/resiliency_math
 user_guide/exploring_model
 user_guide/sdom_math_formulation
+user_guide/zonal_math_formulation
 ```
 
 ```{toctree}

--- a/docs/source/user_guide/exploring_model.md
+++ b/docs/source/user_guide/exploring_model.md
@@ -47,7 +47,7 @@ model.pv.pprint()          # Solar PV block
 model.wind.pprint()         # Wind block
 model.storage.pprint()      # Storage block
 model.thermal.pprint()      # Thermal block
-model.hydro..pprint()        # Hydropower block
+model.hydro.pprint()        # Hydropower block
 model.nuclear.pprint()      # Nuclear block (parameters only)
 model.demand.pprint()       # Demand block (parameters only)
 ```
@@ -76,6 +76,65 @@ You can obtain:
      83c :   1.0
      98c :   1.0
     ```
+
+## Zonal Model Structure (`AreaTransportationModelNetwork`)
+
+When `formulations.csv` includes:
+
+```csv
+Component,Formulation
+Network,AreaTransportationModelNetwork
+```
+
+`initialize_model(...)` builds a zonal model with top-level network objects and per-area blocks.
+
+Top-level zonal objects:
+
+- `model.A`: set of area IDs.
+- `model.area[a]`: area Block for each `a in model.A`.
+- `model.L`: set of interconnections (`line_id`).
+- `model.line_from[l]`, `model.line_to[l]`: line endpoints.
+- `model.LineCap_FT[l,h]`, `model.LineCap_TF[l,h]`: directional hourly capacities.
+- `model.f[l,h]`: signed interregional flow.
+- `model.f_upper[l,h]`, `model.f_lower[l,h]`: directional capacity constraints.
+- `model.L_in[a]`, `model.L_out[a]`: incoming and outgoing lines by area.
+
+Accessing per-area blocks:
+
+```python
+# Example: inspect all area blocks
+for a in model.A:
+    print(f"Area: {a}")
+    model.area[a].pprint()
+
+# Example: inspect area-specific demand and thermal generation
+a0 = list(model.A)[0]
+print(model.area[a0].demand.ts_parameter[1])
+print(model.area[a0].thermal.total_generation)
+```
+
+Accessing network objects:
+
+```python
+# Example: inspect one line and one hour
+l0 = list(model.L)[0]
+h0 = list(model.h)[0]
+
+print(model.line_from[l0], model.line_to[l0])
+print(model.LineCap_FT[l0, h0], model.LineCap_TF[l0, h0])
+print(model.f[l0, h0])
+print(model.f_upper[l0, h0].expr)
+print(model.f_lower[l0, h0].expr)
+```
+
+Zonal supply balance constraints live on each area block:
+
+- `model.area[a].SupplyBalance[h]`
+
+System-wide clean-generation share is top-level:
+
+- `model.GenMix_Share`
+
 ## Model Components
 
 ### Sets

--- a/docs/source/user_guide/inputs.md
+++ b/docs/source/user_guide/inputs.md
@@ -13,6 +13,15 @@ In the next sections each file will be listed and the data it is supossed to be 
 >  - Please keep the root names of each file. For instance, in the sample files you can change "2025" for whatever you prefer, but keeping the root name. For example, for "CapSolar_2025.csv" file you need to keep the root name as "CapSolar_".
 >  - Please do not change the column names of each csv files.
 
+## Zonal Mode Inputs
+
+SDOM supports two network formulations:
+
+- `CopperPlateNetwork`: legacy single-area system-wide balance.
+- `AreaTransportationModelNetwork`: multi-area zonal balance with inter-area transport limits.
+
+For full zonal CSV schema, validation rules, and examples, see [Zonal Inputs](zonal_inputs.md).
+
 
 ## Required Files
 
@@ -43,6 +52,8 @@ This file the user selects the modeling approach (formulation) for each major sy
 | Imports | CapacityPriceNetLoadFormulation | Price-based import optimization |
 | Exports | NotModel | No exports modeled |
 | Exports | CapacityPriceNetLoadFormulation | Price-based export optimization |
+| Network | CopperPlateNetwork | Single-area legacy network model |
+| Network | AreaTransportationModelNetwork | Multi-area transportation network |
 
 **Example**:
 ```csv
@@ -50,6 +61,7 @@ Component,Formulation
 hydro,MonthlyBudgetFormulation
 Imports,CapacityPriceNetLoadFormulation
 Exports,NotModel
+Network,CopperPlateNetwork
 ```
 
 ### 2. Load Data

--- a/docs/source/user_guide/running_and_outputs.md
+++ b/docs/source/user_guide/running_and_outputs.md
@@ -166,6 +166,18 @@ In the path specified by "output_dir", sdom will writhe the following output csv
 | OutputSummary_CASENAME.csv         | Summary of key simulation results and statistics.        |
 | OutputThermalGeneration_CASENAME.csv | Hourly results for thermal generation plants.           |
 | OutputInstalledPowerPlants_CASENAME.csv | Installed capacity for each individual power plant (Solar PV, Wind, Thermal). |
+| OutputInterregionalExchanges_CASENAME.csv | Zonal-only line flows (`line_id`, `from_area`, `to_area`, `hour`, signed and directional flows, directional capacity and utilization). |
+
+## Zonal Results Access
+
+When using `Network=AreaTransportationModelNetwork`, `run_solver` populates zonal fields in `OptimizationResults`:
+
+- `results.is_zonal`
+- `results.areas`, `results.lines`
+- `results.area_generation_df`, `results.area_storage_df`, `results.area_thermal_generation_df`, `results.area_installed_plants_df`, `results.area_summary_df`
+- `results.interregional_exchanges_df`
+
+`results.summary_df` is intentionally empty in the zonal path; use `results.area_summary_df` for per-area summary tables.
 
 ## Troubleshooting
 ### Solver Performance

--- a/docs/source/user_guide/sdom_math_formulation.md
+++ b/docs/source/user_guide/sdom_math_formulation.md
@@ -5,6 +5,8 @@
 > all resources to meet electrical demand at minimum annualized system cost subject to a clean-energy
 > target.
 
+For the zonal multi-area formulation (`Network = AreaTransportationModelNetwork`), see [Zonal Math Formulation](zonal_math_formulation.md).
+
 ---
 
 ## Sets

--- a/docs/source/user_guide/zonal_inputs.md
+++ b/docs/source/user_guide/zonal_inputs.md
@@ -1,0 +1,163 @@
+# Zonal Inputs
+
+This page documents all CSV inputs used when running SDOM with:
+
+```csv
+Component,Formulation
+Network,AreaTransportationModelNetwork
+```
+
+Use this together with [Inputs](inputs.md).
+
+## Zonal Conventions
+
+- `@` is a reserved delimiter in wide CSV headers.
+- Wide files use `<entity>@<area_id>@` columns.
+- Within one file, non-key columns must be all tagged or all untagged.
+- `area_id` values must be consistent across files.
+- In row-oriented files (`CapSolar.csv`, `CapWind.csv`, `Data_BalancingUnits.csv`), IDs must be globally unique across areas.
+- `StorageData.csv` allows repeated technology names across areas because headers are tagged (for example `Li-Ion@A1@`, `Li-Ion@A2@`).
+
+## Network Selector
+
+### formulations.csv
+
+Add a `Network` row:
+
+```csv
+Component,Formulation
+Network,AreaTransportationModelNetwork
+```
+
+Valid values:
+
+- `CopperPlateNetwork`
+- `AreaTransportationModelNetwork`
+
+If `Network` is missing, SDOM defaults to `CopperPlateNetwork`.
+
+## New Zonal Files
+
+### areas.csv
+
+Required in zonal mode.
+
+| Column | Meaning |
+|---|---|
+| `area_id` | Area identifier (primary key). |
+| `description` | Free text description. |
+
+Example:
+
+```csv
+area_id,description
+A1,North area
+A2,South area
+```
+
+### interconnections.csv
+
+Required in zonal mode.
+
+| Column | Meaning |
+|---|---|
+| `line_id` | Line identifier (unique). |
+| `from_area` | Origin area ID. |
+| `to_area` | Destination area ID. |
+
+Example:
+
+```csv
+line_id,from_area,to_area
+L_A1_A2,A1,A2
+```
+
+### LineCap_FT.csv
+
+Required in zonal mode. Hourly directional capacity for `from_area -> to_area`.
+
+### LineCap_TF.csv
+
+Required in zonal mode. Hourly directional capacity for `to_area -> from_area`.
+
+Both line-cap files:
+
+- Must have the same line columns as `interconnections.csv`.
+- Must have the same hour count as the run horizon (`n_hours`).
+- Must be non-negative.
+
+Example:
+
+```csv
+*Hour,L_A1_A2
+1,500
+2,500
+```
+
+## Modified Existing Files in Zonal Mode
+
+### Row-oriented files with area column
+
+- `CapSolar.csv`
+- `CapWind.csv`
+- `Data_BalancingUnits.csv`
+
+Add `area_id` column.
+
+Example:
+
+```csv
+sc_gid,area_id,capacity,CAPEX_M,trans_cap_cost,FOM_M
+132876,A1,430.68,708.55,5323.33,8.29
+Nordeste,A2,1.0,6209.28,0,94.08
+```
+
+### Wide files with tagged headers
+
+Typical files:
+
+- `Load_hourly.csv`
+- `Nucl_hourly.csv`
+- `otre_hourly.csv`
+- `lahy_hourly.csv`
+- `lahy_max_hourly.csv`, `lahy_min_hourly.csv` (if budget hydro)
+- `Import_Cap.csv`, `Import_Prices.csv`
+- `Export_Cap.csv`, `Export_Prices.csv`
+- `StorageData.csv`
+
+Example:
+
+```csv
+*Hour,Load@A1@,Load@A2@
+1,800,600
+2,820,590
+```
+
+### Capacity-factor files
+
+- `CFSolar.csv`
+- `CFWind.csv`
+
+These remain plant-keyed and do not require `@area_id@` tags.
+
+## CopperPlate Aggregation Fallback
+
+If zonal data is loaded while `Network=CopperPlateNetwork`, SDOM aggregates all areas into a single synthetic `default` area.
+
+High-level behavior:
+
+- Hourly demand and capacities are summed.
+- Import/export prices are capacity-weighted averaged.
+- Interconnection and line-cap files are ignored.
+- A warning is logged.
+
+## Validation Summary
+
+Common validation errors in zonal mode:
+
+- Missing required files (`interconnections.csv`, `LineCap_FT.csv`, `LineCap_TF.csv`).
+- Unknown area IDs in tagged columns or topology.
+- Mixed tagged and untagged columns in a single wide file.
+- Duplicate `line_id` or duplicate `(from_area, to_area)` pairs.
+- Negative line capacities.
+- Duplicate plant IDs across areas for row-oriented VRE and balancing-unit files.

--- a/docs/source/user_guide/zonal_math_formulation.md
+++ b/docs/source/user_guide/zonal_math_formulation.md
@@ -1,0 +1,83 @@
+# Zonal Math Formulation
+
+This page documents the zonal SDOM formulation used when:
+
+- `Network = AreaTransportationModelNetwork`
+
+It extends the base formulation in [SDOM Formulation](sdom_math_formulation.md).
+
+## Sets
+
+- $\mathcal{A}$: areas (`model.A`)
+- $\mathcal{L}$: interconnections (`model.L`)
+- $\mathcal{H}$: hours (`model.h`)
+
+For each area $a \in \mathcal{A}$:
+
+- $\mathcal{L}_{in}(a)$: lines ending in $a$ (`model.L_in[a]`)
+- $\mathcal{L}_{out}(a)$: lines starting in $a$ (`model.L_out[a]`)
+
+## Parameters
+
+- $\overline{F}^{FT}_{l,h}$: capacity in `from -> to` direction (`model.LineCap_FT[l,h]`)
+- $\overline{F}^{TF}_{l,h}$: capacity in `to -> from` direction (`model.LineCap_TF[l,h]`)
+
+## Variables
+
+- $f_{l,h} \in \mathbb{R}$: signed line flow (`model.f[l,h]`)
+
+Reporting expressions:
+
+- $f^{FT}_{l,h} = f_{l,h}$ (`model.f_FT[l,h]`)
+- $f^{TF}_{l,h} = -f_{l,h}$ (`model.f_TF[l,h]`)
+
+In reports, SDOM clips directional values to non-negative values.
+
+## Network Constraints
+
+Directional capacity limits are modeled as two explicit constraint blocks:
+
+$$
+f_{l,h} \leq \overline{F}^{FT}_{l,h}
+$$
+
+$$
+-f_{l,h} \leq \overline{F}^{TF}_{l,h}
+$$
+
+These correspond to `model.f_upper[l,h]` and `model.f_lower[l,h]`.
+
+## Per-Area Supply Balance
+
+For each area and hour, SDOM enforces:
+
+$$
+\text{Demand}_{a,h} + \text{Charge}_{a,h} - \text{Discharge}_{a,h} - \text{Gen}_{a,h}^{all} - \sum_{l \in \mathcal{L}_{in}(a)} f_{l,h} + \sum_{l \in \mathcal{L}_{out}(a)} f_{l,h} = 0
+$$
+
+Implemented as `model.area[a].SupplyBalance[h]`.
+
+Sign convention:
+
+- Positive $f_{l,h}$ means flow in `from -> to` direction.
+- Net inflow to area $a$ is subtracted from the left-hand side in the implementation.
+
+## System-Wide Clean Share Constraint
+
+The carbon-free target remains system-wide (not per area). It is built as top-level `model.GenMix_Share`.
+
+## Objective
+
+Zonal objective is the sum of area costs plus a transmission placeholder:
+
+$$
+\min Z = \sum_{a \in \mathcal{A}} \left(Z^{fixed}_a + Z^{variable}_a\right) + Z^{trans}
+$$
+
+Current implementation uses:
+
+$$
+Z^{trans} = 0
+$$
+
+Transmission investment is intentionally deferred.

--- a/docs/source/user_guide/zonal_model.md
+++ b/docs/source/user_guide/zonal_model.md
@@ -1,0 +1,74 @@
+# Zonal Model Guide
+
+This guide describes how to run and inspect the zonal SDOM model.
+
+## When to Use Zonal Mode
+
+Use zonal mode when you need:
+
+- Multiple geographic areas with separate demand/resource profiles.
+- Inter-area transfer limits.
+- Area-level outputs and interregional flow outputs.
+
+## Minimal Setup
+
+1. Set `Network` in `formulations.csv` to `AreaTransportationModelNetwork`.
+2. Provide `areas.csv`, `interconnections.csv`, `LineCap_FT.csv`, and `LineCap_TF.csv`.
+3. Ensure zonal input encoding is valid (see [Zonal Inputs](zonal_inputs.md)).
+
+## Run Example
+
+```python
+from sdom import load_data, initialize_model, run_solver, get_default_solver_config_dict
+
+data = load_data("./Data/zonal_test/")
+model = initialize_model(data, n_hours=24)
+solver_cfg = get_default_solver_config_dict(solver_name="highs")
+results = run_solver(model, solver_cfg)
+
+print(results.is_zonal)
+print(results.areas)
+print(results.lines)
+print(results.interregional_exchanges_df.head())
+```
+
+## Pyomo Object Access
+
+Top-level zonal objects:
+
+- `model.A`, `model.area`
+- `model.L`, `model.line_from`, `model.line_to`
+- `model.LineCap_FT`, `model.LineCap_TF`
+- `model.f`, `model.f_upper`, `model.f_lower`, `model.f_FT`, `model.f_TF`
+
+Per-area objects (for each `a`):
+
+- `model.area[a].demand`
+- `model.area[a].pv`, `model.area[a].wind`, `model.area[a].thermal`
+- `model.area[a].storage`, `model.area[a].hydro`
+- `model.area[a].nuclear`, `model.area[a].other_renewables`
+- `model.area[a].SupplyBalance`
+
+System-wide constraint:
+
+- `model.GenMix_Share`
+
+## Results and Outputs
+
+Zonal-specific result fields:
+
+- `results.is_zonal`
+- `results.areas`, `results.lines`
+- `results.area_generation_df`, `results.area_storage_df`, `results.area_thermal_generation_df`, `results.area_installed_plants_df`, `results.area_summary_df`
+- `results.interregional_exchanges_df`
+
+CSV export adds:
+
+- `OutputInterregionalExchanges_<case>.csv`
+
+## Known Limits (Current Scope)
+
+- Resiliency with `AreaTransportationModelNetwork` is not implemented.
+- Imports/exports under zonal path are currently restricted to `NotModel`.
+- Transmission expansion cost is a placeholder (`Z^trans = 0`).
+- Per-area parametric sweeps are deferred.


### PR DESCRIPTION
## Summary
This PR adds and integrates the missing documentation for the zonal model implementation, aligned with the recent work delivered in the zonal branch. It covers user-facing guidance and API reference updates for zonal inputs, zonal mathematical formulation, zonal model usage, zonal outputs, and zonal Pyomo object access.

## What was implemented

### 1) New zonal user-guide chapters
- Added a dedicated zonal input reference:
  - `docs/source/user_guide/zonal_inputs.md`
- Added a dedicated zonal mathematical formulation page:
  - `docs/source/user_guide/zonal_math_formulation.md`
- Added a zonal model usage guide (run flow, object access, limitations):
  - `docs/source/user_guide/zonal_model.md`

### 2) Existing user-guide pages updated
- Added zonal-mode context and references in:
  - `docs/source/user_guide/inputs.md`
  - `docs/source/user_guide/sdom_math_formulation.md`
  - `docs/source/user_guide/running_and_outputs.md`
  - `docs/source/user_guide/exploring_model.md`
- Included zonal-specific output/result notes, including interregional exchange output and per-area result access.

### 3) API documentation updated
- Added zonal data loading/access notes in:
  - `docs/source/api/io_manager.md`
- Added network formulation coverage and host-pattern notes in:
  - `docs/source/api/models.md`
- Added zonal result fields and collector behavior in:
  - `docs/source/api/results.md`
- Added zonal support notes in parametric API page:
  - `docs/source/api/parametric.md`

### 4) Documentation navigation updated
- Added new zonal pages to the Sphinx toctree in:
  - `docs/source/index.md`

## Commit sequence in this PR
1. `69f2861` docs(user-guide): add zonal documentation chapters and navigation
2. `efd2277` docs(user-guide): document zonal inputs outputs and Pyomo object access
3. `e171e37` docs(api): add zonal network and results coverage

## Validation
- Ran docs build tests:
  - `uv run pytest tests/test_docs_build.py`
- Result: all tests passed.

## Notes
- This PR is documentation-only and does not modify model behavior.
- Content is aligned with the current zonal implementation and deferred scope currently enforced in code (for example, resiliency with zonal network and imports/exports constraints under zonal path).