### PR TITLE
feat(resiliency): SOC recovery-target slack with $1k/MWh penalty (#68)

### DIFF
--- a/docs/source/user_guide/resiliency_math.md
+++ b/docs/source/user_guide/resiliency_math.md
@@ -61,6 +61,7 @@ narrative usage guide is in {doc}`resiliency`.
 | $c^{vom}_{s}$ | Storage VOM (USD/MWh). | `StorageData_*.csv` |
 | $\pi^{slack}$ | Penalty on unserved energy (USD/MWh). Default $10^{4}$. | User (`OutageSpec` / kwarg) |
 | $\pi^{curt}$ | Penalty on curtailed VRE energy (USD/MWh). Default $0$ (free curtailment). | User (kwarg) |
+| $\pi^{soc}$ | Penalty on SOC recovery-target slack (USD/MWh). Default $10^{3}$. Applies to Problem (O) only. | User (kwarg) |
 
 ### 2.4 Outage / operational
 
@@ -169,6 +170,15 @@ Z^{O}_{slack}(h) = \sum_{t \in \mathcal{T}^{out}_h} \pi^{slack} \, u_{t}.
 $$
 
 $$
+Z^{O}_{soc\_slack}(h) = \pi^{soc} \sum_{s \in \mathcal{S}} \sigma^{rec}_{s},
+$$
+
+where $\sigma^{rec}_{s} \ge 0$ is a non-negative slack variable on the
+SOC recovery target (see section 5.5). The operational SOC floor in
+section 5.3 remains a hard bound; only the end-of-recovery target is
+softened.
+
+$$
 Z^{O}_{curt}(h) = \pi^{curt} \sum_{t \in \mathcal{T}^{out}_h} \left[ \sum_{w \in \mathcal{W}} (\delta_{w,t} \, A^{W}_{w,t} \, Cap^{W}_{w} - p^{W}_{w,t}) + \sum_{k \in \mathcal{K}} (\delta_{k,t} \, A^{K}_{k,t} \, Cap^{K}_{k} - p^{K}_{k,t}) \right].
 $$
 
@@ -270,10 +280,14 @@ $$
 SOC_{s,h} = SOC^{base}_{s,h}, \quad \forall s \in \mathcal{S}.
 $$
 
-Recovery target at the end of the recovery window:
+Recovery target at the end of the recovery window (Problem (O) only). In
+Problem (O), the target is **softened by a non-negative slack variable**
+$\sigma^{rec}_{s} \ge 0$ priced at $\pi^{soc}$ in the objective (see section
+4) so the LP remains feasible when storage cannot fully recharge by the
+end of its recovery window. In Problem (B), $\sigma^{rec}_{s} \equiv 0$:
 
 $$
-SOC_{s, h + \Delta^{out} + \Delta^{rec}_{s}} \ge SOC^{rec}_{s} \cdot Cap^{E}_{s},
+SOC_{s, h + \Delta^{out} + \Delta^{rec}_{s}} + \sigma^{rec}_{s} \ge SOC^{rec}_{s} \cdot Cap^{E}_{s},
 \quad \forall s \in \mathcal{S}.
 $$
 

--- a/docs/source/user_guide/resiliency_math.md
+++ b/docs/source/user_guide/resiliency_math.md
@@ -90,6 +90,7 @@ Defined for both problems unless noted. All non-negative.
 | $p^{imp}_{t}, p^{exp}_{t}$ | Imports / exports (MW). |
 | $D^{fix}_{m}, D^{var}_{m}$ | Monthly demand-charge cost (USD), one per month. Defined as the maximum tariff-weighted import in month $m$ via section 5.4. Problem (B) only by default. |
 | $u_{t}$ | Unserved-energy slack (MWh). **Problem (O) only.** |
+| $\sigma^{rec}_{s}$ | SOC recovery-target slack (MWh). Non-negative relaxation of the per-tech end-of-recovery target (section 5.5). **Problem (O) only.** |
 
 ---
 
@@ -144,7 +145,7 @@ multipliers therefore do not appear in (B).
 Minimize the operational cost over the outage horizon
 
 $$
-Z^{O}(h) = Z^{O}_{thermal}(h) + Z^{O}_{storage}(h) + Z^{O}_{imp}(h) + Z^{O}_{exp}(h) + Z^{O}_{slack}(h) + Z^{O}_{curt}(h).
+Z^{O}(h) = Z^{O}_{thermal}(h) + Z^{O}_{storage}(h) + Z^{O}_{imp}(h) + Z^{O}_{exp}(h) + Z^{O}_{slack}(h) + Z^{O}_{soc\_slack}(h) + Z^{O}_{curt}(h).
 $$
 
 with components

--- a/src/sdom/resiliency/evaluate.py
+++ b/src/sdom/resiliency/evaluate.py
@@ -47,6 +47,7 @@ def evaluate_resiliency(
     min_soc_per_tech=None,
     slack_penalty=10_000.0,
     curtailment_penalty=0.0,
+    soc_slack_penalty=1_000.0,
     formulation_overrides=None,
     n_workers=None,
     solver="highs",
@@ -82,6 +83,10 @@ def evaluate_resiliency(
         Default ``10_000``.
     curtailment_penalty : float, optional
         Penalty applied to curtailed VRE energy (USD/MWh). Default ``0``.
+    soc_slack_penalty : float, optional
+        Penalty (USD/MWh) on the per-tech SOC recovery-target slack in the
+        outage LP. Forwarded to :func:`run_resiliency_evaluation` and
+        :func:`build_outage_dispatch`. Default ``1_000``.
     formulation_overrides : dict, optional
         Component formulation overrides forwarded to
         :func:`load_designed_system`.
@@ -175,6 +180,7 @@ def evaluate_resiliency(
         hours=hours,
         slack_penalty=slack_penalty,
         curtailment_penalty=curtailment_penalty,
+        soc_slack_penalty=soc_slack_penalty,
         min_soc_per_tech=min_soc_per_tech,
         n_hours=n_hours,
         n_workers=n_workers,

--- a/src/sdom/resiliency/outage_dispatch.py
+++ b/src/sdom/resiliency/outage_dispatch.py
@@ -267,6 +267,7 @@ def build_outage_dispatch(
     designed_system=None,
     slack_penalty=10_000.0,
     curtailment_penalty=0.0,
+    soc_slack_penalty=1_000.0,
     min_soc_per_tech=None,
     n_hours=8760,
     model_name="SDOM_OutageDispatch",
@@ -294,6 +295,12 @@ def build_outage_dispatch(
         Default ``10_000.0``.
     curtailment_penalty : float, optional
         Penalty on curtailed VRE energy (USD/MWh). Default ``0.0``.
+    soc_slack_penalty : float, optional
+        Penalty :math:`\\pi^{soc}` (USD/MWh) on the per-storage-tech
+        slack variable that relaxes the SOC recovery-target constraint
+        (see notes). Default ``1_000.0``. The operational SOC floor
+        remains a hard bound; only the end-of-recovery target is
+        relaxed.
     min_soc_per_tech : dict, optional
         Operational SOC floor per storage tech (fraction of ``Cap_E``).
         Same semantics as :func:`build_baseline_dispatch`.
@@ -631,11 +638,23 @@ def build_outage_dispatch(
                 float(recovery_target_frac_local.get(s, 0.0)) * cap_e
             )
 
+        # Recovery-target SOC slack (#68): non-negative per-tech relaxation
+        # of the end-of-recovery target. The operational SOC floor stays
+        # a hard bound; only this end-of-recovery target is softened.
+        model.recovery_soc_slack = pyo.Var(
+            storage_block.S,
+            domain=pyo.NonNegativeReals,
+            initialize=0.0,
+        )
+
         def _recovery_target_rule(m, s):
             t_end = recovery_end_hour[s]
             if t_end < start_hour or t_end > end_hour:
                 return pyo.Constraint.Skip
-            return storage_block.SOC[s, t_end] >= recovery_target_MWh_local[s]
+            return (
+                storage_block.SOC[s, t_end] + model.recovery_soc_slack[s]
+                >= recovery_target_MWh_local[s]
+            )
 
         model.recovery_target = pyo.Constraint(
             storage_block.S, rule=_recovery_target_rule
@@ -649,6 +668,7 @@ def build_outage_dispatch(
     # Objective
     slack_pen = float(slack_penalty)
     curt_pen = float(curtailment_penalty)
+    soc_slack_pen = float(soc_slack_penalty)
 
     def _add_objective():
         obj_expr = (
@@ -657,6 +677,8 @@ def build_outage_dispatch(
             + imports_block.total_cost_expr
             - exports_block.revenue_expr
             + slack_pen * sum(model.u[t] for t in model.h)
+            + soc_slack_pen
+            * sum(model.recovery_soc_slack[s] for s in storage_techs)
             + curt_pen
             * (
                 solar_block.potential_minus_dispatch
@@ -684,6 +706,7 @@ def build_outage_dispatch(
         "delta_other_renewables": delta_other,
         "slack_penalty": slack_pen,
         "curtailment_penalty": curt_pen,
+        "soc_slack_penalty": soc_slack_pen,
         "designed_system": designed_system,
     }
     if profiler is not None:

--- a/src/sdom/resiliency/outage_dispatch.py
+++ b/src/sdom/resiliency/outage_dispatch.py
@@ -665,11 +665,16 @@ def build_outage_dispatch(
         profiler, "Add recovery target constraint", _build_recovery_target
     )
 
-slack_pen = float(slack_penalty)
-curt_pen = float(curtailment_penalty)
-soc_slack_pen = float(soc_slack_penalty)
-if soc_slack_pen < 0:
-    raise ValueError("soc_slack_penalty must be non-negative.")
+    # Objective
+    slack_pen = float(slack_penalty)
+    curt_pen = float(curtailment_penalty)
+    soc_slack_pen = float(soc_slack_penalty)
+    if slack_pen < 0:
+        raise ValueError("slack_penalty must be non-negative.")
+    if curt_pen < 0:
+        raise ValueError("curtailment_penalty must be non-negative.")
+    if soc_slack_pen < 0:
+        raise ValueError("soc_slack_penalty must be non-negative.")
 
     def _add_objective():
         obj_expr = (

--- a/src/sdom/resiliency/outage_dispatch.py
+++ b/src/sdom/resiliency/outage_dispatch.py
@@ -665,10 +665,11 @@ def build_outage_dispatch(
         profiler, "Add recovery target constraint", _build_recovery_target
     )
 
-    # Objective
-    slack_pen = float(slack_penalty)
-    curt_pen = float(curtailment_penalty)
-    soc_slack_pen = float(soc_slack_penalty)
+slack_pen = float(slack_penalty)
+curt_pen = float(curtailment_penalty)
+soc_slack_pen = float(soc_slack_penalty)
+if soc_slack_pen < 0:
+    raise ValueError("soc_slack_penalty must be non-negative.")
 
     def _add_objective():
         obj_expr = (

--- a/src/sdom/resiliency/runner.py
+++ b/src/sdom/resiliency/runner.py
@@ -114,7 +114,8 @@ def _solve_one_hour(payload: dict[str, Any]) -> dict[str, Any]:
         Flat dictionary with keys
         ``baseline_results``, ``outage_spec``, ``designed_system``,
         ``start_hour``, ``slack_penalty``, ``curtailment_penalty``,
-        ``min_soc_per_tech``, ``n_hours``, ``solver``, ``solver_options``.
+        ``soc_slack_penalty``, ``min_soc_per_tech``, ``n_hours``,
+        ``solver``, ``solver_options``.
 
     Returns
     -------
@@ -160,6 +161,7 @@ def _solve_one_hour(payload: dict[str, Any]) -> dict[str, Any]:
             designed_system=designed_system,
             slack_penalty=float(payload["slack_penalty"]),
             curtailment_penalty=float(payload["curtailment_penalty"]),
+            soc_slack_penalty=float(payload.get("soc_slack_penalty", 1_000.0)),
             min_soc_per_tech=payload.get("min_soc_per_tech"),
             n_hours=n_hours,
             profile=bool(payload.get("profile", False)),
@@ -239,6 +241,7 @@ def run_resiliency_evaluation(
     hours=None,
     slack_penalty=10_000.0,
     curtailment_penalty=0.0,
+    soc_slack_penalty=1_000.0,
     min_soc_per_tech=None,
     n_hours=8760,
     n_workers=None,
@@ -275,6 +278,10 @@ def run_resiliency_evaluation(
         Penalty (USD/MWh) applied to slack ``u[t]``. Default ``10_000``.
     curtailment_penalty : float, optional
         Penalty applied to curtailed VRE energy (USD/MWh). Default ``0``.
+    soc_slack_penalty : float, optional
+        Penalty (USD/MWh) applied to the per-tech SOC recovery-target
+        slack variable in the outage LP. Forwarded to
+        :func:`build_outage_dispatch`. Default ``1_000``.
     min_soc_per_tech : dict, optional
         Operational SOC floor per storage tech (fraction of ``Cap_E``);
         forwarded to the outage builder.
@@ -364,6 +371,7 @@ def run_resiliency_evaluation(
             "start_hour": h,
             "slack_penalty": float(slack_penalty),
             "curtailment_penalty": float(curtailment_penalty),
+            "soc_slack_penalty": float(soc_slack_penalty),
             "min_soc_per_tech": min_soc_per_tech,
             "n_hours": n_hours,
             "solver": solver,

--- a/tests/test_resiliency_outage_dispatch.py
+++ b/tests/test_resiliency_outage_dispatch.py
@@ -330,6 +330,104 @@ def test_outage_demand_charges_excluded_by_default():
     assert not hasattr(model.imports, "D_var")
 
 
+# ---------------------------------------------------------------------------
+# SOC recovery-target slack (#68)
+# ---------------------------------------------------------------------------
+def test_outage_recovery_soc_slack_default_value_and_metadata():
+    n = 24
+    ds = _make_designed_system(n=n)
+    br = _make_baseline_results(ds, soc_value=20.0)
+    spec = OutageSpec(
+        duration_hours=4,
+        recovery_hours=4,
+        outaged_assets={"balancing_units": "all"},
+    )
+    model = build_outage_dispatch(
+        br,
+        start_hour=1,
+        outage_spec=spec,
+        designed_system=ds,
+        n_hours=n,
+    )
+    assert model._sdom_outage_meta["soc_slack_penalty"] == pytest.approx(1_000.0)
+    assert hasattr(model, "recovery_soc_slack")
+    slack = model.recovery_soc_slack
+    assert isinstance(slack, pyo.Var)
+    assert slack["Li-Ion"].domain is pyo.NonNegativeReals
+
+
+def test_outage_recovery_soc_slack_penalty_override():
+    n = 24
+    ds = _make_designed_system(n=n)
+    br = _make_baseline_results(ds, soc_value=20.0)
+    spec = OutageSpec(
+        duration_hours=4,
+        recovery_hours=4,
+        outaged_assets={"balancing_units": "all"},
+    )
+    model = build_outage_dispatch(
+        br,
+        start_hour=1,
+        outage_spec=spec,
+        designed_system=ds,
+        n_hours=n,
+        soc_slack_penalty=2_500.0,
+    )
+    assert model._sdom_outage_meta["soc_slack_penalty"] == pytest.approx(2_500.0)
+
+
+def test_outage_recovery_target_constraint_includes_slack():
+    n = 24
+    ds = _make_designed_system(n=n)
+    br = _make_baseline_results(ds, soc_value=0.0)
+    spec = OutageSpec(
+        duration_hours=4,
+        recovery_hours=4,
+        outaged_assets={"balancing_units": "all"},
+        min_soc_recovery={"Li-Ion": 0.7},
+    )
+    model = build_outage_dispatch(
+        br,
+        start_hour=1,
+        outage_spec=spec,
+        designed_system=ds,
+        n_hours=n,
+    )
+    # The recovery_target constraint for Li-Ion must mention the new slack var.
+    con = model.recovery_target["Li-Ion"]
+    body_str = str(con.expr)
+    assert "recovery_soc_slack[Li-Ion]" in body_str
+
+
+def test_outage_recovery_soc_slack_resolves_unreachable_target():
+    solver = _highs()
+    n = 24
+    ds = _make_designed_system(n=n)
+    br = _make_baseline_results(ds, soc_value=0.0)
+    # Recovery window for start_hour=1, duration=4, recovery=2 ends at hour 6.
+    # With both balancing_units and storage outaged, storage can only charge
+    # during recovery hours 5..6 (Cap_Pch=10 -> max 20 MWh), so a 40 MWh
+    # recovery target is unreachable and slack must absorb ~20 MWh.
+    spec = OutageSpec(
+        duration_hours=4,
+        recovery_hours=2,
+        outaged_assets={"balancing_units": "all", "storage": "all"},
+        min_soc_recovery={"Li-Ion": 1.0},
+    )
+    model = build_outage_dispatch(
+        br,
+        start_hour=1,
+        outage_spec=spec,
+        designed_system=ds,
+        n_hours=n,
+        soc_slack_penalty=1_000.0,
+    )
+    result = solver.solve(model)
+    assert str(result.solver.termination_condition).lower() == "optimal"
+    slack_value = pyo.value(model.recovery_soc_slack["Li-Ion"])
+    assert slack_value > 10.0  # ~20 MWh expected; well above numerical noise
+
+
 def test_outage_solves_feasible_zero_outage_equivalence():
     solver = _highs()
     n = 24

--- a/tests/test_resiliency_outage_dispatch.py
+++ b/tests/test_resiliency_outage_dispatch.py
@@ -376,6 +376,26 @@ def test_outage_recovery_soc_slack_penalty_override():
     assert model._sdom_outage_meta["soc_slack_penalty"] == pytest.approx(2_500.0)
 
 
+def test_outage_recovery_soc_slack_penalty_negative_rejected():
+    n = 24
+    ds = _make_designed_system(n=n)
+    br = _make_baseline_results(ds, soc_value=20.0)
+    spec = OutageSpec(
+        duration_hours=4,
+        recovery_hours=4,
+        outaged_assets={"balancing_units": "all"},
+    )
+    with pytest.raises(ValueError, match="soc_slack_penalty must be non-negative"):
+        build_outage_dispatch(
+            br,
+            start_hour=1,
+            outage_spec=spec,
+            designed_system=ds,
+            n_hours=n,
+            soc_slack_penalty=-1.0,
+        )
+
+
 def test_outage_recovery_target_constraint_includes_slack():
     n = 24
     ds = _make_designed_system(n=n)


### PR DESCRIPTION
Closes #68 (sub-issue of #67).

## Summary

Adds a non-negative slack variable on the per-storage-tech end-of-recovery SOC target in the outage dispatch LP, priced at a configurable penalty (default `$1,000/MWh`) in the outage objective. The operational SOC floor remains a **hard bound**; only the recovery target is softened so the LP stays feasible when storage cannot fully recharge by the end of its recovery window.

Maintainer scope decisions locked in https://github.com/Omar0902/SDOM/issues/68#issuecomment-4654365753:
- SOC slack scope: **recovery target only**
- Default SOC slack penalty: **`$1,000/MWh`**

## Changes

- `src/sdom/resiliency/outage_dispatch.py`
  - New keyword-only kwarg `soc_slack_penalty=1_000.0`.
  - New `model.recovery_soc_slack` (`NonNegativeReals`) indexed by storage tech.
  - `model.recovery_target` constraint changed from `SOC[s, t_end] >= target` to `SOC[s, t_end] + recovery_soc_slack[s] >= target`.
  - Objective gains `soc_slack_pen * sum(recovery_soc_slack[s] for s in storage_techs)`.
  - `_sdom_outage_meta["soc_slack_penalty"]` recorded.
  - Docstring updated (NumPy style).
- `src/sdom/resiliency/runner.py`: `run_resiliency_evaluation` accepts `soc_slack_penalty`; payload forwards it to the worker; worker forwards to `build_outage_dispatch`.
- `src/sdom/resiliency/evaluate.py`: top-level `evaluate_resiliency` accepts and forwards `soc_slack_penalty`.
- `docs/source/user_guide/resiliency_math.md`: documents `π^{soc}` parameter, `σ^{rec}_s` slack variable, recovery-target relaxation, and new objective term.
- `tests/test_resiliency_outage_dispatch.py`: 4 new tests:
  - default value + metadata + var domain,
  - penalty override,
  - constraint expression contains slack var,
  - solver-backed: unreachable recovery target → slack > 0.

## Backward compatibility

Additive kwarg with default. When the recovery target is reachable, the slack stays at 0 (LP optimum trivially), so numerical results for existing call sites are unchanged regardless of the penalty value.

## Validation

```
uv run pytest tests/test_resiliency_outage_dispatch.py
# 14 passed
```

10 failures in `tests/test_resiliency_baseline_dispatch.py` and `tests/test_resiliency_evaluate.py` are **pre-existing on the branch tip `463a794`** (`designed_system.cem_data is required`) and not caused by this PR.

## Out of scope

- Probability-weighted resiliency metrics (tracked under sibling sub-issue #69).
- Slack on the operational SOC floor (maintainer decided: recovery target only).
- Changes to `src/sdom/models/formulations_resiliency.py` (design stage).
