### PR TITLE
feat(resiliency): probability-weighted expected metrics over outage realizations (#69)

### DIFF
--- a/docs/source/user_guide/resiliency.md
+++ b/docs/source/user_guide/resiliency.md
@@ -278,15 +278,34 @@ results.to_dataframe()        # same data with `hour` promoted to a column
 ```python
 agg = results.metrics(level="aggregate")
 # {
-#   "LOLP":             # P(EUE(h) > 0)
-#   "LOLE":             # mean USE_hours per scenario
+#   "LOLP":              # P(EUE(h) > 0)
+#   "LOLE":              # mean USE_hours per scenario
 #   "mean_EUE":
 #   "max_EUE":
 #   "EUE_p50", "EUE_p95", "EUE_p99":
+#   "EUE_expected":      # sum_h P(h) * EUE(h)        (issue #69)
+#   "USE_hours_expected":# sum_h P(h) * USE_hours(h)  (issue #69)
 #   "n_hours_evaluated": # excludes errored worker rows
 #   "n_errors":
 # }
 ```
+
+#### Probability-weighted expected metrics (renormalize)
+
+``EUE_expected`` and ``USE_hours_expected`` apply an outage-start
+probability ``P(h)`` per evaluated anchor hour and report the expected
+value:
+
+``EUE_expected = sum_h P(h) * EUE(h)``,
+``USE_hours_expected = sum_h P(h) * USE_hours(h)``.
+
+The default convention is **renormalize**: ``P(h) = 1 / len(hours)`` over
+the evaluated (non-errored) anchor set so the weights sum to ``1`` even
+when only a subset of the year was simulated. With uniform weights this
+identically equals the existing ``mean_EUE`` / ``LOLE`` values; the keys
+are carried separately so future severity-weighted schemes can replace
+the uniform weight without changing the persisted ``summary.json``
+schema or the existing unweighted metric names.
 
 Convenience accessors mirror common reliability-engineering quantities:
 

--- a/docs/source/user_guide/resiliency.md
+++ b/docs/source/user_guide/resiliency.md
@@ -283,9 +283,9 @@ agg = results.metrics(level="aggregate")
 #   "mean_EUE":
 #   "max_EUE":
 #   "EUE_p50", "EUE_p95", "EUE_p99":
-#   "EUE_expected":      # sum_h P(h) * EUE(h)        (issue #69)
-#   "USE_hours_expected":# sum_h P(h) * USE_hours(h)  (issue #69)
-#   "n_hours_evaluated": # excludes errored worker rows
+#   "EUE_expected":       # sum_h P(h) * EUE(h)        (issue #69)
+#   "USE_hours_expected": # sum_h P(h) * USE_hours(h)  (issue #69)
+#   "n_hours_evaluated":  # excludes errored worker rows
 #   "n_errors":
 # }
 ```

--- a/docs/source/user_guide/resiliency_math.md
+++ b/docs/source/user_guide/resiliency_math.md
@@ -385,6 +385,37 @@ $$
 EUE_{\max} = \max_{h \in \mathcal{H}} EUE(h).
 $$
 
+### 7.3 Probability-weighted expected metrics
+
+Each evaluated anchor hour $h \in \mathcal{H}$ is assigned an outage-start
+probability $P(h)$ and the *expected* metrics are reported alongside the
+unweighted statistics in section 7.2:
+
+$$
+EUE^{\text{exp}} = \sum_{h \in \mathcal{H}} P(h) \cdot EUE(h), \qquad
+H_{USE}^{\text{exp}} = \sum_{h \in \mathcal{H}} P(h) \cdot H_{USE}(h).
+$$
+
+**Partial-evaluation convention (renormalize).** When only a subset
+$\mathcal{H} \subsetneq \mathcal{T}$ of anchor hours is evaluated (e.g. an
+explicit ``hours=`` list passed to ``evaluate_resiliency``), probabilities
+are renormalized over the evaluated set so they sum to 1:
+
+$$
+P(h) = \frac{1}{\lvert \mathcal{H} \rvert}, \qquad
+\sum_{h \in \mathcal{H}} P(h) = 1.
+$$
+
+Hours with ``solver_status == "error"`` are excluded from $\mathcal{H}$
+before renormalize, mirroring the unweighted statistics in section 7.2.
+
+With uniform $P(h) = 1 / N_{H}$ the identities
+$EUE^{\text{exp}} \equiv \overline{EUE}$ and
+$H_{USE}^{\text{exp}} \equiv LOLE$ hold by construction. The keys are
+surfaced separately so future severity- or arrival-rate-weighted schemes
+can replace the uniform weight without changing the persisted schema or
+breaking the existing unweighted metric names.
+
 The empirical distribution $\lbrace EUE(h) \rbrace_{h \in \mathcal{H}}$ is
 exposed via {class}`~sdom.resiliency.ResiliencyResults` and underlies the
 histogram / ECDF / exceedance plots described in {doc}`resiliency`.

--- a/src/sdom/resiliency/system_state.py
+++ b/src/sdom/resiliency/system_state.py
@@ -274,8 +274,8 @@ class ResiliencyResults:
         -----
         Probability-weighted expected metrics use the renormalize convention
         (issue #69, Q1): each evaluated anchor hour carries weight
-        ``P(h) = 1 / len(hours)`` over the evaluated (non-errored) set
-        ``\\mathcal{H}``. Consequently ``EUE_expected`` collapses to
+        ``P(h) = 1 / len(hours)`` over the evaluated (non-errored) anchor
+        set. Consequently ``EUE_expected`` collapses to
         ``mean_EUE`` and ``USE_hours_expected`` collapses to ``LOLE`` when
         the per-hour probabilities are uniform; this is by design, not a
         bug. The keys are persisted so future severity-weighted schemes

--- a/src/sdom/resiliency/system_state.py
+++ b/src/sdom/resiliency/system_state.py
@@ -268,7 +268,19 @@ class ResiliencyResults:
         return df
 
     def _aggregate_metrics(self) -> dict:
-        """Compute the aggregate-metrics dict (Phase 6 spec)."""
+        """Compute the aggregate-metrics dict (Phase 6 + #69).
+
+        Notes
+        -----
+        Probability-weighted expected metrics use the renormalize convention
+        (issue #69, Q1): each evaluated anchor hour carries weight
+        ``P(h) = 1 / len(hours)`` over the evaluated (non-errored) set
+        ``\\mathcal{H}``. Consequently ``EUE_expected`` collapses to
+        ``mean_EUE`` and ``USE_hours_expected`` collapses to ``LOLE`` when
+        the per-hour probabilities are uniform; this is by design, not a
+        bug. The keys are persisted so future severity-weighted schemes
+        can replace the uniform weight without changing the schema.
+        """
         df = self._evaluated_frame()
         n_eval = int(len(df))
         if "solver_status" in self.per_hour.columns:
@@ -285,6 +297,8 @@ class ResiliencyResults:
                 "EUE_p50": float("nan"),
                 "EUE_p95": float("nan"),
                 "EUE_p99": float("nan"),
+                "EUE_expected": float("nan"),
+                "USE_hours_expected": float("nan"),
                 "n_hours_evaluated": 0,
                 "n_errors": n_err,
             }
@@ -295,6 +309,9 @@ class ResiliencyResults:
         else:
             use_hours = np.zeros(n_eval)
 
+        # Q1=renormalize: P(h) = 1 / len(hours) over the evaluated anchor set.
+        prob = 1.0 / n_eval
+
         return {
             "LOLP": float(np.mean(eue > 0.0)),
             "LOLE": float(np.mean(use_hours)),
@@ -303,6 +320,8 @@ class ResiliencyResults:
             "EUE_p50": float(np.percentile(eue, 50, method="linear")),
             "EUE_p95": float(np.percentile(eue, 95, method="linear")),
             "EUE_p99": float(np.percentile(eue, 99, method="linear")),
+            "EUE_expected": float(np.sum(prob * eue)),
+            "USE_hours_expected": float(np.sum(prob * use_hours)),
             "n_hours_evaluated": n_eval,
             "n_errors": n_err,
         }

--- a/tests/test_resiliency_metrics.py
+++ b/tests/test_resiliency_metrics.py
@@ -92,6 +92,67 @@ def test_metrics_invalid_level_raises():
         results.metrics(level="bogus")
 
 
+def test_metrics_includes_probability_weighted_expected_keys():
+    """Aggregate metrics expose ``EUE_expected`` and ``USE_hours_expected``."""
+    results = _make_results()
+    m = results.metrics(level="aggregate")
+
+    assert "EUE_expected" in m
+    assert "USE_hours_expected" in m
+
+
+def test_expected_metrics_uniform_renormalize_matches_mean():
+    """Q1=renormalize: ``P(h) = 1/len(hours)`` => expected == unweighted mean.
+
+    With the renormalize convention, the probability-weighted expected
+    metrics over a partial-evaluation set collapse to the arithmetic mean
+    of the evaluated hours. Documented to avoid being mistaken for a bug.
+    """
+    results = _make_results()
+    m = results.metrics(level="aggregate")
+
+    assert m["EUE_expected"] == pytest.approx(m["mean_EUE"])
+    assert m["USE_hours_expected"] == pytest.approx(m["LOLE"])
+
+
+def test_expected_metrics_subset_renormalize_convention():
+    """Subset evaluation: weights renormalize to 1/n_eval, not 1/n_total."""
+    eue = [0.0, 4.0, 8.0]
+    use_hours = [0, 1, 3]
+    results = _make_results(eue=eue, use_hours=use_hours, n=3)
+    m = results.metrics(level="aggregate")
+
+    assert m["EUE_expected"] == pytest.approx((0.0 + 4.0 + 8.0) / 3)
+    assert m["USE_hours_expected"] == pytest.approx((0 + 1 + 3) / 3)
+
+
+def test_expected_metrics_identity_sum_p_times_eue():
+    """``EUE_expected == sum_h P_h * EUE_h`` on a synthetic frame."""
+    results = _make_results()
+    m = results.metrics(level="aggregate")
+
+    eue = np.asarray(_EUE_VALUES, dtype=float)
+    p_h = 1.0 / len(eue)
+    assert m["EUE_expected"] == pytest.approx(float(np.sum(p_h * eue)))
+
+
+def test_expected_metrics_exclude_errored_hours():
+    """Errored hours are dropped before renormalize, like unweighted stats."""
+    eue = list(_EUE_VALUES)
+    eue[8] = float("nan")
+    statuses = ["optimal"] * 10
+    statuses[8] = "error"
+    results = _make_results(eue=eue, statuses=statuses)
+
+    m = results.metrics(level="aggregate")
+    remaining = [v for i, v in enumerate(_EUE_VALUES) if i != 8]
+    assert m["n_errors"] == 1
+    assert m["n_hours_evaluated"] == 9
+    assert m["EUE_expected"] == pytest.approx(sum(remaining) / 9)
+    # Existing unweighted metric must remain unchanged in name and value.
+    assert m["mean_EUE"] == pytest.approx(np.mean(remaining))
+
+
 def test_convenience_scalars():
     results = _make_results()
     arr = np.asarray(_EUE_VALUES, dtype=float)

--- a/tests/test_resiliency_results_persistence.py
+++ b/tests/test_resiliency_results_persistence.py
@@ -99,3 +99,40 @@ def test_summary_json_contents(tmp_path):
 def test_load_missing_files_raises(tmp_path):
     with pytest.raises(FileNotFoundError, match="per_hour.parquet"):
         ResiliencyResults.load(tmp_path / "nonexistent")
+
+
+def test_summary_contains_expected_metric_keys(tmp_path):
+    """summary.json includes the probability-weighted expected metrics (#69)."""
+    results = _make_results()
+    results.save(tmp_path)
+
+    payload = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    agg = payload["aggregate_metrics"]
+
+    assert "EUE_expected" in agg
+    assert "USE_hours_expected" in agg
+    assert isinstance(agg["EUE_expected"], float)
+    assert isinstance(agg["USE_hours_expected"], float)
+
+
+def test_load_summary_missing_expected_keys_is_backward_compatible(tmp_path):
+    """An older ``summary.json`` without expected keys still loads cleanly."""
+    original = _make_results()
+    original.save(tmp_path)
+
+    # Rewrite summary.json with the legacy aggregate_metrics shape (no
+    # ``EUE_expected`` / ``USE_hours_expected``), mimicking a pre-#69 file.
+    summary_path = tmp_path / "summary.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    payload["aggregate_metrics"] = {
+        k: v
+        for k, v in payload["aggregate_metrics"].items()
+        if k not in {"EUE_expected", "USE_hours_expected"}
+    }
+    summary_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = ResiliencyResults.load(tmp_path)
+    # Loader must not raise; recomputed metrics expose the new keys.
+    m = loaded.metrics(level="aggregate")
+    assert "EUE_expected" in m
+    assert "USE_hours_expected" in m


### PR DESCRIPTION
Closes #69 (sub-issue of #67).

## Summary

Adds probability-weighted *expected* resiliency metrics over outage
realizations in `ResiliencyResults._aggregate_metrics`, alongside the
existing unweighted statistics. The unweighted metric keys and values
(`LOLP`, `LOLE`, `mean_EUE`, `max_EUE`, `EUE_p50/95/99`,
`n_hours_evaluated`, `n_errors`) are **unchanged**.

New keys:

| Key | Definition |
|---|---|
| `EUE_expected` | `sum_h P(h) * EUE(h)` (MWh) |
| `USE_hours_expected` | `sum_h P(h) * USE_hours(h)` |

## Probability convention (Q1 = renormalize)

Per the maintainer's answer on #69:

```
P(h) = 1 / len(hours)
```

over the **evaluated (non-errored)** anchor set `H`, so the weights sum to
`1` even when only a subset of the year was simulated. Errored hours are
excluded from `H` before renormalize, mirroring the unweighted metrics.

With uniform weights this collapses to `EUE_expected == mean_EUE` and
`USE_hours_expected == LOLE` by construction. The keys are surfaced
separately so future severity- or arrival-rate-weighted schemes can
replace the uniform weight without changing the persisted schema or
breaking existing unweighted metric names. This is explicitly documented
(`resiliency_math.md` §7.3 and `resiliency.md`).

## Persistence (Q2 = in scope now)

`summary.json` now carries the two new keys in `aggregate_metrics`. The
loader (`ResiliencyResults.load`) is naturally backward-compatible
because it recomputes aggregates from `per_hour` rather than reading them
from `summary.json`; a new test (`test_resiliency_results_persistence.py`)
pins this by writing a legacy-shaped `summary.json` and asserting that
`load(...).metrics(level="aggregate")` still exposes the new keys.

## TDD trail

Red → green per `.github/instructions/sdom-standards.instructions.md`.
New tests:

`tests/test_resiliency_metrics.py`
- `test_metrics_includes_probability_weighted_expected_keys`
- `test_expected_metrics_uniform_renormalize_matches_mean`
- `test_expected_metrics_subset_renormalize_convention`
- `test_expected_metrics_identity_sum_p_times_eue`
- `test_expected_metrics_exclude_errored_hours`

`tests/test_resiliency_results_persistence.py`
- `test_summary_contains_expected_metric_keys`
- `test_load_summary_missing_expected_keys_is_backward_compatible`

Local validation:

```
uv run pytest tests/test_resiliency_metrics.py \
              tests/test_resiliency_results_persistence.py \
              tests/test_resiliency_plotting.py \
              tests/test_resiliency_outage_spec.py --no-cov -q
# 31 passed, 1 skipped (pyarrow-gated persistence tests skipped in this env)
```

## Docs

- `docs/source/user_guide/resiliency_math.md` — new §7.3 with formulas
  and the renormalize convention.
- `docs/source/user_guide/resiliency.md` — aggregate-metrics block updated
  with new keys and partial-evaluation convention.

## Non-goals

- No changes to the outage LP, slack variables, or penalties (#68
  territory).
- No regeneration of prior sweep outputs.
- No public-API rename or removal of existing unweighted metric keys.

## Diffstat

5 files changed, 170 insertions(+), 3 deletions(-) — well under the
~500 LOC PR target.

Base: `sm/resiliency_testing` (matches #68 / PR #70 pattern).
