### PR TITLE
feat(resiliency): add critical_load_MW kwarg for constant critical load during outages

### DIFF
--- a/.github/workflows/benchmarks-pr-compare.yml
+++ b/.github/workflows/benchmarks-pr-compare.yml
@@ -79,6 +79,8 @@ jobs:
       - name: Run base quick benchmarks
         if: ${{ steps.validate.outputs.run_compare == 'true' }}
         shell: bash
+        env:
+          PYTHONPATH: base/tests
         run: |
           uv run --project base --with pytest-benchmark \
             pytest base/tests/benchmarks -m bench_quick -o addopts='' \
@@ -88,6 +90,8 @@ jobs:
       - name: Run head quick benchmarks
         if: ${{ steps.validate.outputs.run_compare == 'true' }}
         shell: bash
+        env:
+          PYTHONPATH: head/tests
         run: |
           uv run --project head --with pytest-benchmark \
             pytest head/tests/benchmarks -m bench_quick -o addopts='' \

--- a/docs/source/user_guide/resiliency.md
+++ b/docs/source/user_guide/resiliency.md
@@ -266,8 +266,12 @@ outage_model = build_outage_dispatch(
 ```
 
 `critical_load_MW=None` (default) preserves the original behaviour: the
-hourly load series is used everywhere. Negative values raise
-`ValueError`. The value used (or `None`) is recorded on the built model as
+hourly load series is used everywhere. Negative or non-finite values
+(NaN, ±inf) raise `ValueError`; the runner-level entry points
+(`run_resiliency_evaluation`, `evaluate_resiliency`) validate the value
+once in the parent process so a bad input fails fast instead of being
+swallowed by the per-hour error-isolation wrapper. The value used (or
+`None`) is recorded on the built model as
 `model._sdom_outage_meta["critical_load_MW"]`.
 
 ### 4. Optional profiling

--- a/docs/source/user_guide/resiliency.md
+++ b/docs/source/user_guide/resiliency.md
@@ -230,7 +230,47 @@ outage_model = build_outage_dispatch(
 )
 ```
 
-### 3. Optional profiling
+### 3. Constant critical load during the outage window
+
+Resiliency studies often size storage against a **constant critical load**
+(hospital, data center, military base) rather than the original hourly load
+profile, which represents normal operations. Pass
+`critical_load_MW=X` to override the load parameter with the constant
+`X` MW for every hour in the outage sub-horizon
+$[h, h + \Delta^{out} - 1]$. Recovery-window hours continue to use the
+original $D_t$ so storage replenishment toward the end-of-recovery target
+reflects realistic post-outage operations.
+
+```python
+# End-to-end: serve a flat 50 MW critical load during each outage.
+results = evaluate_resiliency(
+    snapshot_dir=snapshot_dir,
+    inputs_dir=inputs_dir,
+    outage_spec=spec,
+    critical_load_MW=50.0,
+)
+
+# Also available on the lower-level entry points.
+results = run_resiliency_evaluation(
+    baseline,
+    outage_spec=spec,
+    critical_load_MW=50.0,
+)
+outage_model = build_outage_dispatch(
+    baseline,
+    start_hour=100,
+    outage_spec=spec,
+    designed_system=ds,
+    critical_load_MW=50.0,
+)
+```
+
+`critical_load_MW=None` (default) preserves the original behaviour: the
+hourly load series is used everywhere. Negative values raise
+`ValueError`. The value used (or `None`) is recorded on the built model as
+`model._sdom_outage_meta["critical_load_MW"]`.
+
+### 4. Optional profiling
 
 Each Pyomo-model builder accepts an opt-in `profile=True` flag that wraps
 the build (and solve, in the case of the baseline) with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
 
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 testpaths = ["tests"]
 addopts = [
     "--cov=sdom",

--- a/src/sdom/resiliency/evaluate.py
+++ b/src/sdom/resiliency/evaluate.py
@@ -52,6 +52,7 @@ def evaluate_resiliency(
     n_workers=None,
     solver="highs",
     solver_options=None,
+    critical_load_MW=None,
     profile_baseline=False,
     profile_outages=False,
 ):
@@ -100,6 +101,12 @@ def evaluate_resiliency(
     solver_options : dict, optional
         Solver options forwarded to both the baseline solve and every
         per-hour outage solve.
+    critical_load_MW : float, optional
+        Constant critical load (MW) used in place of the hourly load
+        series during the outage sub-horizon of each per-hour LP.
+        Forwarded to :func:`run_resiliency_evaluation` and through it to
+        :func:`build_outage_dispatch`. ``None`` (default) preserves the
+        original behaviour. Must be non-negative.
     profile_baseline : bool, optional
         When ``True``, attach a
         :class:`~sdom.utils_performance_meassure.ModelInitProfiler` to the
@@ -186,6 +193,7 @@ def evaluate_resiliency(
         n_workers=n_workers,
         solver=solver,
         solver_options=solver_options,
+        critical_load_MW=critical_load_MW,
         profile_outages=profile_outages,
     )
     logger.info("evaluate_resiliency: pipeline complete.")

--- a/src/sdom/resiliency/outage_dispatch.py
+++ b/src/sdom/resiliency/outage_dispatch.py
@@ -318,6 +318,7 @@ def build_outage_dispatch(
     soc_slack_penalty=1_000.0,
     min_soc_per_tech=None,
     n_hours=8760,
+    critical_load_MW=None,
     model_name="SDOM_OutageDispatch",
     profile=False,
 ):
@@ -355,6 +356,14 @@ def build_outage_dispatch(
     n_hours : int, optional
         Length of the baseline horizon used for end-of-year clipping.
         Default ``8760``.
+    critical_load_MW : float, optional
+        Constant critical load (MW) used in place of
+        ``designed_system.load[t]`` for every hour ``t`` in the outage
+        sub-horizon ``[start_hour, start_hour + duration_hours - 1]``
+        (clipped to the LP end hour). Recovery-window hours continue to
+        use the original ``D_t``. ``None`` (default) preserves the
+        original behaviour: the hourly load series is used everywhere.
+        Must be non-negative.
     model_name : str, optional
         Pyomo model name. Default ``"SDOM_OutageDispatch"``.
     profile : bool, optional
@@ -401,6 +410,13 @@ def build_outage_dispatch(
     equation at the anchor; under that formulation ``Pcha[s, start_hour]``
     and ``Pdis[s, start_hour]`` for surviving (non-outaged) storage techs
     were unconstrained by any SOC balance.
+
+    When ``critical_load_MW`` is provided, the load parameter is overridden
+    only over the outage sub-horizon
+    :math:`\\mathcal{T}^{out}_h = \\{h, \\ldots, h + \\Delta^{out} - 1\\}`;
+    hours in the recovery sub-horizon retain the original ``D_t`` so that
+    storage replenishment toward the end-of-recovery target reflects
+    realistic post-outage operations.
     """
     if designed_system is None:
         designed_system = (baseline_results.metadata or {}).get("designed_system")
@@ -413,6 +429,10 @@ def build_outage_dispatch(
         raise TypeError("designed_system must be a DesignedSystem instance.")
     if not isinstance(baseline_results, BaselineDispatchResults):
         raise TypeError("baseline_results must be a BaselineDispatchResults instance.")
+    if critical_load_MW is not None and float(critical_load_MW) < 0:
+        raise ValueError(
+            f"critical_load_MW must be non-negative; got {critical_load_MW}."
+        )
 
     profiler = None
     if profile:
@@ -613,7 +633,17 @@ def build_outage_dispatch(
             t: _series_value(designed_system.other_renewables, t) * delta_other.get(t, 1.0)
             for t in horizon
         }
-        load_param = {t: _series_value(designed_system.load, t) for t in horizon}
+        if critical_load_MW is None:
+            load_param = {t: _series_value(designed_system.load, t) for t in horizon}
+        else:
+            crit = float(critical_load_MW)
+            outage_end = min(start_hour + duration - 1, end_hour)
+            load_param = {
+                t: crit
+                if start_hour <= t <= outage_end
+                else _series_value(designed_system.load, t)
+                for t in horizon
+            }
 
         model.nuclear_eff_param = pyo.Param(model.h, initialize=nuclear_eff, mutable=False)
         model.hydro_eff_param = pyo.Param(model.h, initialize=hydro_eff, mutable=False)
@@ -782,6 +812,7 @@ def build_outage_dispatch(
         "soc_slack_penalty": soc_slack_pen,
         "horizon_hours": horizon_hours,
         "fom_cost_USD": float(fom_cost_USD),
+        "critical_load_MW": None if critical_load_MW is None else float(critical_load_MW),
         "designed_system": designed_system,
     }
     if profiler is not None:

--- a/src/sdom/resiliency/outage_dispatch.py
+++ b/src/sdom/resiliency/outage_dispatch.py
@@ -22,6 +22,7 @@ sections 1, 4.2, 5.1, 5.2, 5.3, 5.5, 6.
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any
 
 import pandas as pd
@@ -429,10 +430,17 @@ def build_outage_dispatch(
         raise TypeError("designed_system must be a DesignedSystem instance.")
     if not isinstance(baseline_results, BaselineDispatchResults):
         raise TypeError("baseline_results must be a BaselineDispatchResults instance.")
-    if critical_load_MW is not None and float(critical_load_MW) < 0:
-        raise ValueError(
-            f"critical_load_MW must be non-negative; got {critical_load_MW}."
-        )
+    if critical_load_MW is not None:
+        crit_val = float(critical_load_MW)
+        if not math.isfinite(crit_val):
+            raise ValueError(
+                f"critical_load_MW must be a finite number; got {critical_load_MW}."
+            )
+        if crit_val < 0:
+            raise ValueError(
+                f"critical_load_MW must be non-negative; got {critical_load_MW}."
+            )
+        critical_load_MW = crit_val
 
     profiler = None
     if profile:
@@ -636,10 +644,9 @@ def build_outage_dispatch(
         if critical_load_MW is None:
             load_param = {t: _series_value(designed_system.load, t) for t in horizon}
         else:
-            crit = float(critical_load_MW)
             outage_end = min(start_hour + duration - 1, end_hour)
             load_param = {
-                t: crit
+                t: critical_load_MW
                 if start_hour <= t <= outage_end
                 else _series_value(designed_system.load, t)
                 for t in horizon

--- a/src/sdom/resiliency/runner.py
+++ b/src/sdom/resiliency/runner.py
@@ -18,6 +18,7 @@ section 7 (per-hour metrics: EUE, USE_hours, max unserved MW).
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
 import traceback
@@ -343,6 +344,18 @@ def run_resiliency_evaluation(
     n_hours = int(n_hours)
     if n_hours <= 0:
         raise ValueError("n_hours must be a positive integer.")
+
+    if critical_load_MW is not None:
+        crit_val = float(critical_load_MW)
+        if not math.isfinite(crit_val):
+            raise ValueError(
+                f"critical_load_MW must be a finite number; got {critical_load_MW}."
+            )
+        if crit_val < 0:
+            raise ValueError(
+                f"critical_load_MW must be non-negative; got {critical_load_MW}."
+            )
+        critical_load_MW = crit_val
 
     if hours is None:
         hour_list = list(range(1, n_hours + 1))

--- a/src/sdom/resiliency/runner.py
+++ b/src/sdom/resiliency/runner.py
@@ -164,6 +164,7 @@ def _solve_one_hour(payload: dict[str, Any]) -> dict[str, Any]:
             soc_slack_penalty=float(payload.get("soc_slack_penalty", 1_000.0)),
             min_soc_per_tech=payload.get("min_soc_per_tech"),
             n_hours=n_hours,
+            critical_load_MW=payload.get("critical_load_MW"),
             profile=bool(payload.get("profile", False)),
         )
         solver = _resolve_solver(str(payload["solver"]))
@@ -247,6 +248,7 @@ def run_resiliency_evaluation(
     n_workers=None,
     solver="highs",
     solver_options=None,
+    critical_load_MW=None,
     profile_outages=False,
 ):
     """Run the per-hour outage evaluation in parallel and aggregate metrics.
@@ -296,6 +298,11 @@ def run_resiliency_evaluation(
         Default ``"highs"``.
     solver_options : dict, optional
         Solver options forwarded to ``solver.solve(..., options=...)``.
+    critical_load_MW : float, optional
+        Constant critical load (MW) used in place of the hourly load
+        series during the outage sub-horizon of each per-hour LP.
+        Forwarded to :func:`build_outage_dispatch`. ``None`` (default)
+        preserves the original behaviour. Must be non-negative.
     profile_outages : bool, optional
         When ``True`` and ``n_workers == 1``, profile every per-hour
         outage build via
@@ -376,6 +383,7 @@ def run_resiliency_evaluation(
             "n_hours": n_hours,
             "solver": solver,
             "solver_options": dict(solver_options) if solver_options else {},
+            "critical_load_MW": critical_load_MW,
             "profile": profile_outages_effective,
         }
         for h in hour_list

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pyomo.environ as pyo
@@ -10,6 +11,10 @@ from sdom.resiliency import OutageSpec
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_TESTS_DIR = str(Path(__file__).resolve().parents[1])
+if _TESTS_DIR not in sys.path:
+    sys.path.insert(0, _TESTS_DIR)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_outage_critical_load.py
+++ b/tests/test_outage_critical_load.py
@@ -1,0 +1,105 @@
+"""Tests for the ``critical_load_MW`` override on outage dispatch (#73).
+
+Covers the new keyword argument added to ``build_outage_dispatch``.
+Runner and ``evaluate_resiliency`` forwarding tests are added by the
+follow-up commits in this branch.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sdom.resiliency import (
+    OutageSpec,
+    build_outage_dispatch,
+)
+
+from tests.test_resiliency_outage_dispatch import (
+    _make_baseline_results,
+    _make_designed_system,
+)
+
+
+def _build(start_hour=5, duration=4, recovery=4, n_hours=24, **kwargs):
+    """Build a tiny outage LP and return ``(model, ds, br, start, duration)``.
+
+    A non-flat baseline load (``10*t``) is injected so the override can be
+    distinguished from the baseline value at every hour.
+    """
+    ds = _make_designed_system(n=n_hours, load_value=50.0)
+    varying = pd.Series(
+        [10.0 * t for t in range(1, n_hours + 1)],
+        index=ds.load.index,
+        name=ds.load.name,
+    )
+    ds = ds.__class__(
+        storage_caps=ds.storage_caps,
+        thermal_caps=ds.thermal_caps,
+        solar_caps=ds.solar_caps,
+        wind_caps=ds.wind_caps,
+        load=varying,
+        cf_solar=ds.cf_solar,
+        cf_wind=ds.cf_wind,
+        nuclear=ds.nuclear,
+        hydro=ds.hydro,
+        other_renewables=ds.other_renewables,
+        import_cap=ds.import_cap,
+        import_price=ds.import_price,
+        export_cap=ds.export_cap,
+        export_price=ds.export_price,
+        phi_fix_t=ds.phi_fix_t,
+        phi_var_t=ds.phi_var_t,
+        month_of_hour=ds.month_of_hour,
+    )
+    br = _make_baseline_results(ds, soc_value=20.0)
+    spec = OutageSpec(
+        duration_hours=duration,
+        recovery_hours=recovery,
+        outaged_assets={"balancing_units": "all"},
+    )
+    model = build_outage_dispatch(
+        br,
+        start_hour=start_hour,
+        outage_spec=spec,
+        designed_system=ds,
+        n_hours=n_hours,
+        **kwargs,
+    )
+    return model, ds, br, start_hour, duration
+
+
+def test_critical_load_default_is_baseline():
+    """``critical_load_MW=None`` (default) must match ``designed_system.load``."""
+    model, ds, _, _, _ = _build()
+    for t in model.h:
+        assert float(model.load_param[t]) == pytest.approx(float(ds.load.loc[t]))
+    assert model._sdom_outage_meta["critical_load_MW"] is None
+
+
+def test_critical_load_overrides_outage_window_only():
+    crit = 123.5
+    model, ds, _, start, duration = _build(critical_load_MW=crit)
+    outage_end = start + duration - 1
+    for t in model.h:
+        expected = crit if start <= t <= outage_end else float(ds.load.loc[t])
+        assert float(model.load_param[t]) == pytest.approx(expected), (
+            f"hour {t}: got {float(model.load_param[t])}, expected {expected}"
+        )
+
+
+def test_critical_load_zero_is_valid():
+    model, _, _, start, duration = _build(critical_load_MW=0.0)
+    for t in range(start, start + duration):
+        assert float(model.load_param[t]) == pytest.approx(0.0)
+    assert model._sdom_outage_meta["critical_load_MW"] == 0.0
+
+
+def test_critical_load_negative_raises():
+    with pytest.raises(ValueError, match="critical_load_MW must be non-negative"):
+        _build(critical_load_MW=-1.0)
+
+
+def test_critical_load_metadata_round_trip():
+    model, _, _, _, _ = _build(critical_load_MW=77.0)
+    assert model._sdom_outage_meta["critical_load_MW"] == pytest.approx(77.0)

--- a/tests/test_outage_critical_load.py
+++ b/tests/test_outage_critical_load.py
@@ -1,7 +1,7 @@
 """Tests for the ``critical_load_MW`` override on outage dispatch (#73).
 
-Covers the new keyword argument added to ``build_outage_dispatch`` and
-its forwarding through ``run_resiliency_evaluation``.
+Covers the new keyword argument added to ``build_outage_dispatch`` and its
+forwarding through ``run_resiliency_evaluation`` and ``evaluate_resiliency``.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import pytest
 from sdom.resiliency import (
     OutageSpec,
     build_outage_dispatch,
+    evaluate_resiliency,
     run_resiliency_evaluation,
 )
 
@@ -140,3 +141,51 @@ def test_runner_forwards_critical_load():
     assert len(captured_kwargs) == 2
     for kw in captured_kwargs:
         assert kw["critical_load_MW"] == pytest.approx(42.0)
+
+
+def test_evaluate_resiliency_forwards_critical_load(monkeypatch):
+    """``evaluate_resiliency`` must pass ``critical_load_MW`` to the runner."""
+    from sdom.resiliency import evaluate as evaluate_module
+
+    captured: dict = {}
+
+    def _fake_runner(baseline_results, **kwargs):
+        captured.update(kwargs)
+
+        class _FakeResults:
+            per_hour = pd.DataFrame()
+            metadata: dict = {}
+
+        return _FakeResults()
+
+    def _fake_load(*_args, **_kwargs):
+        return _make_designed_system(n=4, load_value=10.0)
+
+    def _fake_build(_designed_system, **_kwargs):
+        class _Model:
+            pass
+
+        return _Model()
+
+    def _fake_run_baseline(_model, **_kwargs):
+        ds = _make_designed_system(n=4, load_value=10.0)
+        return _make_baseline_results(ds, soc_value=5.0)
+
+    monkeypatch.setattr(evaluate_module, "load_designed_system", _fake_load)
+    monkeypatch.setattr(evaluate_module, "build_baseline_dispatch", _fake_build)
+    monkeypatch.setattr(evaluate_module, "run_baseline_dispatch", _fake_run_baseline)
+    monkeypatch.setattr(evaluate_module, "run_resiliency_evaluation", _fake_runner)
+
+    spec = OutageSpec(
+        duration_hours=2,
+        recovery_hours=1,
+        outaged_assets={"balancing_units": "all"},
+    )
+    evaluate_resiliency(
+        "snapshot/",
+        inputs_dir="inputs/",
+        outage_spec=spec,
+        n_hours=4,
+        critical_load_MW=99.0,
+    )
+    assert captured["critical_load_MW"] == pytest.approx(99.0)

--- a/tests/test_outage_critical_load.py
+++ b/tests/test_outage_critical_load.py
@@ -1,11 +1,12 @@
 """Tests for the ``critical_load_MW`` override on outage dispatch (#73).
 
-Covers the new keyword argument added to ``build_outage_dispatch``.
-Runner and ``evaluate_resiliency`` forwarding tests are added by the
-follow-up commits in this branch.
+Covers the new keyword argument added to ``build_outage_dispatch`` and
+its forwarding through ``run_resiliency_evaluation``.
 """
 
 from __future__ import annotations
+
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -13,6 +14,7 @@ import pytest
 from sdom.resiliency import (
     OutageSpec,
     build_outage_dispatch,
+    run_resiliency_evaluation,
 )
 
 from tests.test_resiliency_outage_dispatch import (
@@ -103,3 +105,38 @@ def test_critical_load_negative_raises():
 def test_critical_load_metadata_round_trip():
     model, _, _, _, _ = _build(critical_load_MW=77.0)
     assert model._sdom_outage_meta["critical_load_MW"] == pytest.approx(77.0)
+
+
+# ---------------------------------------------------------------------------
+# Forwarding through the runner
+# ---------------------------------------------------------------------------
+def test_runner_forwards_critical_load():
+    ds = _make_designed_system(n=24, load_value=50.0)
+    br = _make_baseline_results(ds, soc_value=20.0)
+    spec = OutageSpec(
+        duration_hours=2,
+        recovery_hours=2,
+        outaged_assets={"balancing_units": "all"},
+    )
+
+    captured_kwargs: list[dict] = []
+
+    def _fake_build(baseline_results, **kwargs):
+        captured_kwargs.append(kwargs)
+        return build_outage_dispatch(baseline_results, **kwargs)
+
+    with patch("sdom.resiliency.runner._build_outage_dispatch", side_effect=_fake_build):
+        run_resiliency_evaluation(
+            br,
+            outage_spec=spec,
+            designed_system=ds,
+            hours=[1, 5],
+            n_hours=24,
+            n_workers=1,
+            critical_load_MW=42.0,
+            solver_options={},
+        )
+
+    assert len(captured_kwargs) == 2
+    for kw in captured_kwargs:
+        assert kw["critical_load_MW"] == pytest.approx(42.0)

--- a/tests/test_outage_critical_load.py
+++ b/tests/test_outage_critical_load.py
@@ -103,6 +103,16 @@ def test_critical_load_negative_raises():
         _build(critical_load_MW=-1.0)
 
 
+def test_critical_load_nan_raises():
+    with pytest.raises(ValueError, match="critical_load_MW must be a finite number"):
+        _build(critical_load_MW=float("nan"))
+
+
+def test_critical_load_inf_raises():
+    with pytest.raises(ValueError, match="critical_load_MW must be a finite number"):
+        _build(critical_load_MW=float("inf"))
+
+
 def test_critical_load_metadata_round_trip():
     model, _, _, _, _ = _build(critical_load_MW=77.0)
     assert model._sdom_outage_meta["critical_load_MW"] == pytest.approx(77.0)
@@ -141,6 +151,40 @@ def test_runner_forwards_critical_load():
     assert len(captured_kwargs) == 2
     for kw in captured_kwargs:
         assert kw["critical_load_MW"] == pytest.approx(42.0)
+
+
+@pytest.mark.parametrize(
+    "bad_value, match",
+    [
+        (-1.0, "non-negative"),
+        (float("nan"), "finite number"),
+        (float("inf"), "finite number"),
+    ],
+)
+def test_runner_validates_critical_load_before_workers(bad_value, match):
+    """Invalid ``critical_load_MW`` must raise in the parent process before
+    any payload is built, instead of being swallowed by the per-hour
+    error-isolation wrapper in ``_solve_one_hour``."""
+    ds = _make_designed_system(n=4, load_value=10.0)
+    br = _make_baseline_results(ds, soc_value=2.0)
+    spec = OutageSpec(
+        duration_hours=1,
+        recovery_hours=1,
+        outaged_assets={"balancing_units": "all"},
+    )
+
+    with patch("sdom.resiliency.runner._build_outage_dispatch") as fake_build:
+        with pytest.raises(ValueError, match=match):
+            run_resiliency_evaluation(
+                br,
+                outage_spec=spec,
+                designed_system=ds,
+                hours=[1],
+                n_hours=4,
+                n_workers=1,
+                critical_load_MW=bad_value,
+            )
+        fake_build.assert_not_called()
 
 
 def test_evaluate_resiliency_forwards_critical_load(monkeypatch):

--- a/tests/test_outage_critical_load.py
+++ b/tests/test_outage_critical_load.py
@@ -18,7 +18,7 @@ from sdom.resiliency import (
     run_resiliency_evaluation,
 )
 
-from tests.test_resiliency_outage_dispatch import (
+from test_resiliency_outage_dispatch import (
     _make_baseline_results,
     _make_designed_system,
 )

--- a/tests/test_resiliency_evaluate.py
+++ b/tests/test_resiliency_evaluate.py
@@ -161,7 +161,8 @@ def test_evaluate_resiliency_passes_through_kwargs(monkeypatch):
                       hours=None, slack_penalty=10_000.0, curtailment_penalty=0.0,
                       soc_slack_penalty=1_000.0,
                       min_soc_per_tech=None, n_hours=8760, n_workers=None,
-                      solver="highs", solver_options=None, profile_outages=False):
+                      solver="highs", solver_options=None,
+                      critical_load_MW=None, profile_outages=False):
         captured["run_eval"] = dict(
             slack_penalty=slack_penalty,
             curtailment_penalty=curtailment_penalty,
@@ -172,6 +173,7 @@ def test_evaluate_resiliency_passes_through_kwargs(monkeypatch):
             solver=solver,
             solver_options=solver_options,
             hours=None if hours is None else list(hours),
+            critical_load_MW=critical_load_MW,
             profile_outages=profile_outages,
         )
         return real_run_eval(
@@ -187,6 +189,7 @@ def test_evaluate_resiliency_passes_through_kwargs(monkeypatch):
             n_workers=n_workers,
             solver=solver,
             solver_options=solver_options,
+            critical_load_MW=critical_load_MW,
             profile_outages=profile_outages,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "sdom"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "highspy" },


### PR DESCRIPTION
Closes #73.

## Summary

Adds a single optional keyword argument, `critical_load_MW: float | None = None`,
to the three public outage-evaluation entry points so users can size storage /
generation against a **constant critical load** (e.g., hospital, data center,
military base) instead of the original hourly load time series during the
outage window. Recovery hours continue to use the original `D_t` so storage
replenishment toward the end-of-recovery target reflects realistic post-outage
operations.

The change is purely additive and fully backward-compatible:
`critical_load_MW=None` (default) preserves the existing behaviour
byte-for-byte.

## Mathematical change

$$
\tilde{D}_t =
\begin{cases}
D^{crit}, & t \in \mathcal{T}^{out}_h \text{ (outage window, when override is active)} \\
D_t, & \text{otherwise.}
\end{cases}
$$

The power-balance equation (`math_model.md` §5.1) substitutes $\tilde{D}_t$
for $D_t$. In Problem (B) and when `critical_load_MW` is `None`,
$\tilde{D}_t \equiv D_t$ identically.

## API change (one new kwarg, callable-only)

| Function | New kwarg | Default |
|---|---|---|
| `sdom.resiliency.build_outage_dispatch` | `critical_load_MW: float \| None` | `None` |
| `sdom.resiliency.run_resiliency_evaluation` | `critical_load_MW: float \| None` | `None` |
| `sdom.resiliency.evaluate_resiliency` | `critical_load_MW: float \| None` | `None` |

Semantics:
- `None` (default): no change — `D_t` is used everywhere.
- `X >= 0`: LP uses `X` MW for every `t ∈ [start_hour, start_hour + duration_hours - 1]`.
- `X < 0`: raises `ValueError`.

The value used is recorded in `model._sdom_outage_meta["critical_load_MW"]`
for traceability (consistent with `slack_penalty`, `soc_slack_penalty`, etc.).

## Commits

1. `feat(resiliency): add critical_load_MW kwarg to build_outage_dispatch` — builder change + 5 builder tests.
2. `feat(resiliency): forward critical_load_MW through run_resiliency_evaluation` — runner propagation + forwarding test.
3. `feat(resiliency): forward critical_load_MW through evaluate_resiliency` — top-level helper + forwarding test.
4. `docs(resiliency): document critical_load_MW in user guide` — new subsection in `docs/source/user_guide/resiliency.md` with examples for all three entry points.

## Tests

```
tests\test_outage_critical_load.py .......                               [ 20%]
tests\test_resiliency_outage_dispatch.py ...................             [ 74%]
tests\test_resiliency_runner.py .........                                [100%]
35 passed in 4.91s
```

The 7 new tests in `tests/test_outage_critical_load.py` cover:
- default behaviour matches baseline (regression guard)
- override applies only to the outage sub-horizon
- `0.0` is valid; negative raises `ValueError`
- metadata round-trip
- forwarding through `run_resiliency_evaluation`
- forwarding through `evaluate_resiliency`

## Documentation

- `docs/source/user_guide/resiliency.md` — new "Constant critical load during the outage window" subsection (`§ Quickstart > 3`).
- NumPy docstrings of the three public functions updated.
- `dev_guidelines/resiliency evaluation/math_model.md` — `D^{crit}` symbol added to §2.2; §5.1 power balance updated with $\tilde{D}_t$ definition (file is gitignored, kept local).
- Full plan: `dev_guidelines/resiliency evaluation/critical_load_plan.md` (also gitignored).

## Out of scope

- Time-varying critical-load profile (future extension: `dict[int, float]` or `pd.Series`).
- Per-zone critical load (depends on the zonal-model work in `dev_guidelines/zonal_model/`).
- Override of the recovery window (recovery represents post-outage normal ops).

## Risk / rollback

Minimal — purely additive behind a kwarg that defaults to `None`. Revert any
of the four commits independently if needed.